### PR TITLE
Make seeds.rb idempotent: use find_or_initialize_by for User to avoid…

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,7 +25,8 @@ unless Rails.env.production?
     name: 'Acme Org'
   )
 
-  user = User.new(name: 'John', email: 'john@acme.inc', password: 'Password1!', type: 'SuperAdmin')
+  user = User.find_or_initialize_by(email: 'john@acme.inc')
+  user.assign_attributes(name: 'John', password: 'Password1!', type: 'SuperAdmin')
   user.skip_confirmation!
   user.save!
 


### PR DESCRIPTION
## Description

This PR ensures the seed file is **idempotent** by modifying how the default admin user is created.
Previously, running `rails db:seed` multiple times would result in a `Validation failed: Email has already been taken` error because the user with the same email was being inserted unconditionally.

This fix changes the logic to use `User.find_or_initialize_by(email: ...)` and `assign_attributes(...)`, allowing repeated seeding without creating duplicates or raising validation errors.

Fixes: No formal issue number, but resolves common local setup/development disruption.

---

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

---

## How Has This Been Tested?

### Test Steps:

1. Reset the database:

   ```bash
   rails db:reset
   ```

2. Run seed file for the first time:

   ```bash
   rails db:seed
   # Seed completed successfully
   ```

3. Run seed file again:

   ```bash
   rails db:seed
   # No errors, no duplicate users created
   ```

4. Verify in Rails console:

   ```ruby
   User.where(email: 'john@acme.inc').count
   # => 1
   ```

### Environment:

* OS: Ubuntu 24.04
* Ruby: 3.4.4 (via rbenv)
* Rails: latest master
* DB: PostgreSQL 16