### PR TITLE
Implement message editing functionality with context menu integration

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -25,6 +25,23 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
     end
   end
 
+  def edit
+    new_content = params[:content]
+    
+    if message.edit_message!(new_content, current_user)
+      render json: { 
+        status: 'success', 
+        message: message.reload,
+        edit_history: message.content_attributes['editHistory'] || {}
+      }
+    else
+      render json: { 
+        status: 'error', 
+        message: 'Cannot edit this message' 
+      }, status: :unprocessable_entity
+    end
+  end
+
   def retry
     return if message.blank?
 
@@ -65,7 +82,7 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
   end
 
   def permitted_params
-    params.permit(:id, :target_language, :status, :external_error)
+    params.permit(:id, :target_language, :status, :external_error, :content)
   end
 
   def already_translated_content_available?

--- a/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/MessagesView.vue
@@ -123,6 +123,13 @@ export default {
       isProgrammaticScroll: false,
       messageSentSinceOpened: false,
       labelSuggestions: [],
+      // Edit mode state
+      editMode: {
+        active: false,
+        messageId: null,
+        content: '',
+        conversationId: null
+      }
     };
   },
 
@@ -510,6 +517,29 @@ export default {
         return false;
       });
     },
+    
+    // Edit mode handlers
+    handleEditMessage(editData) {
+      this.editMode = {
+        active: true,
+        messageId: editData.messageId,
+        content: editData.content,
+        conversationId: editData.conversationId
+      };
+    },
+    
+    cancelEditMode() {
+      this.editMode = {
+        active: false,
+        messageId: null,
+        content: '',
+        conversationId: null
+      };
+    },
+    
+    onEditComplete() {
+      this.cancelEditMode();
+    },
   },
 };
 </script>
@@ -598,6 +628,7 @@ export default {
         :is-instagram="isInstagramDM"
         :inbox-supports-reply-to="inboxSupportsReplyTo"
         :in-reply-to="getInReplyToMessage(message)"
+        @edit-message="handleEditMessage"
       />
       <li v-show="unreadMessageCount != 0" class="unread--toast">
         <span>
@@ -622,6 +653,7 @@ export default {
         :is-instagram-dm="isInstagramDM"
         :inbox-supports-reply-to="inboxSupportsReplyTo"
         :in-reply-to="getInReplyToMessage(message)"
+        @edit-message="handleEditMessage"
       />
       <ConversationLabelSuggestion
         v-if="shouldShowLabelSuggestions"
@@ -654,7 +686,10 @@ export default {
       </div>
       <ReplyBox
         v-model:popout-reply-box="isPopOutReplyBox"
+        :edit-mode="editMode"
         @toggle-popout="showPopOutReplyBox"
+        @edit-complete="onEditComplete"
+        @edit-cancel="cancelEditMode"
       />
     </div>
   </div>

--- a/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/bubble/Actions.vue
@@ -54,6 +54,10 @@ export default {
       type: [String, Number],
       default: 0,
     },
+    contentAttributes: {
+      type: Object,
+      default: () => ({}),
+    },
   },
   computed: {
     inbox() {
@@ -106,6 +110,12 @@ export default {
         return true;
       }
       return false;
+    },
+    isEdited() {
+      return this.contentAttributes?.editHistory?.isEdited === true;
+    },
+    editCount() {
+      return this.contentAttributes?.editHistory?.editCount || 0;
     },
     showSentIndicator() {
       if (!this.showStatusIndicators) {
@@ -187,6 +197,13 @@ export default {
     >
       {{ readableTime }}
     </span>
+    <span 
+      v-if="isEdited" 
+      class="edited-indicator"
+      v-tooltip.top-start="editCount > 1 ? `Edited ${editCount} times` : 'Edited'"
+    >
+      (edited)
+    </span>
     <span v-if="externalError" class="read-indicator-wrap">
       <fluent-icon
         v-tooltip.top-start="externalError"
@@ -259,6 +276,10 @@ export default {
       @apply text-woot-100 dark:text-woot-100;
     }
 
+    .edited-indicator {
+      @apply text-woot-200 dark:text-woot-200;
+    }
+
     .action--icon {
       @apply text-white dark:text-white;
 
@@ -290,6 +311,10 @@ export default {
 
   .time {
     @apply mr-2 block text-xxs leading-[1.8];
+  }
+
+  .edited-indicator {
+    @apply mr-2 text-xxs text-slate-400 dark:text-slate-500 italic leading-[1.8];
   }
 
   .action--icon {

--- a/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
+++ b/app/javascript/dashboard/modules/conversations/components/MessageContextMenu.vue
@@ -44,7 +44,7 @@ export default {
       default: false,
     },
   },
-  emits: ['open', 'close', 'replyTo'],
+  emits: ['open', 'close', 'replyTo', 'editMessage'],
   setup() {
     const { getPlainText } = useMessageFormatter();
 
@@ -130,6 +130,10 @@ export default {
       this.$emit('replyTo', this.message);
       this.handleClose();
     },
+    handleEdit() {
+      this.$emit('editMessage', this.message);
+      this.handleClose();
+    },
     openDeleteModal() {
       this.handleClose();
       this.showDeleteModal = true;
@@ -211,6 +215,15 @@ export default {
           }"
           variant="icon"
           @click.stop="handleCopy"
+        />
+        <MenuItem
+          v-if="enabledOptions['edit']"
+          :option="{
+            icon: 'edit',
+            label: 'Edit Message',
+          }"
+          variant="icon"
+          @click.stop="handleEdit"
         />
         <MenuItem
           v-if="enabledOptions['translate']"

--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -177,23 +177,26 @@ export const mutations = {
     });
   },
 
-  [types.ADD_MESSAGE]({ allConversations, selectedChatId }, message) {
+  [types.ADD_MESSAGE](_state, message) {
     const { conversation_id: conversationId } = message;
-    const [chat] = getSelectedChatConversation({
-      allConversations,
-      selectedChatId: conversationId,
-    });
-    if (!chat) return;
-
+    const [chat] = getSelectedChatConversation(_state, conversationId);
+    
+    if (!chat) {
+      return;
+    }
+    
     const pendingMessageIndex = findPendingMessageIndex(chat, message);
+    
     if (pendingMessageIndex !== -1) {
+      // Update existing message (for edits)
       chat.messages[pendingMessageIndex] = message;
     } else {
+      // Add new message
       chat.messages.push(message);
       chat.timestamp = message.created_at;
       const { conversation: { unread_count: unreadCount = 0 } = {} } = message;
       chat.unread_count = unreadCount;
-      if (selectedChatId === conversationId) {
+      if (_state.selectedChatId === conversationId) {
         emitter.emit(BUS_EVENTS.FETCH_LABEL_SUGGESTIONS);
         emitter.emit(BUS_EVENTS.SCROLL_TO_MESSAGE);
       }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,7 @@ Rails.application.routes.draw do
                 member do
                   post :translate
                   post :retry
+                  patch :edit
                 end
               end
               resources :assignments, only: [:create]


### PR DESCRIPTION
## Description
This PR introduces enhanced conversation capabilities to the Chatwoot platform, focused on message editing and meaningful payload enrichment:

**Message Editing Support**:

- Contextual editing is enabled via a right-click menu for a user’s own outgoing messages.

- Messages are editable for up to 5 minutes post-send, after which editing is disabled automatically.

- The reply input is reused in "edit mode" to provide full rich text editing capabilities.

- A clear visual edit mode banner is displayed with cancel support.

- Edited messages display a subtle “(edited)” indicator with a tooltip showing edit count.

- Backend changes include a dedicated endpoint for editing, with full edit history tracked.

---

## Type of Change

- [x] Feature (message editing support with content_attributes)

- [x] UI/UX improvement (context menu integration, real-time feedback)

---

## Test Steps

1. Run the frontend and validate message editing:

   - Send a message as a logged-in user.

   - Right-click on the message → select “Edit Message”.

   - Modify content using the reply box.

   - Confirm:

     - Editing allowed only within 5 minutes.

     - “(edited)” badge appears after change.

     - Tooltip shows how many times the message was edited.

2. Verify edge cases:

   - Cannot edit after timeout.

   - Canceling edit restores original content.

   - No "Edit" option for received/incoming messages.

---

## Screenshots

![Screenshot (11)](https://github.com/user-attachments/assets/1024a140-98e0-46af-b2f1-840254acf683)

![Screenshot (12)](https://github.com/user-attachments/assets/02a9d911-d661-4f86-a1d3-797b5bd3f44c)

![Screenshot (13)](https://github.com/user-attachments/assets/79970a5e-e46c-4a11-a2a3-1988acf9bb74)
